### PR TITLE
✨ Feature: 인증, 인가 실패 처리 로직 추가

### DIFF
--- a/src/main/java/com/dev/kioki/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/kioki/global/common/code/status/ErrorStatus.java
@@ -40,7 +40,8 @@ public enum ErrorStatus implements BaseErrorCode {
     LOGOUT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH_004", "로그아웃된 access 토큰 입니다."),
     INVALID_REQUEST_BODY(HttpStatus.BAD_REQUEST, "AUTH_005", "잘못된 요청 본문입니다."),
     INVALID_REQUEST_HEADER(HttpStatus.BAD_REQUEST, "AUTH_006", "잘못된 요청 헤더입니다."),
-    AUTHORIZATION_HEADER_MISSING(HttpStatus.UNAUTHORIZED, "AUTH_015", "Authorization 헤더가 비어있습니다.")
+    AUTHORIZATION_HEADER_MISSING(HttpStatus.UNAUTHORIZED, "AUTH_015", "Authorization 헤더가 비어있습니다."),
+    USER_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "AUTH_013", "유저 인증에 실패했습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dev/kioki/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/dev/kioki/global/common/code/status/ErrorStatus.java
@@ -42,6 +42,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_REQUEST_HEADER(HttpStatus.BAD_REQUEST, "AUTH_006", "잘못된 요청 헤더입니다."),
     AUTHORIZATION_HEADER_MISSING(HttpStatus.UNAUTHORIZED, "AUTH_015", "Authorization 헤더가 비어있습니다."),
     USER_AUTHENTICATION_FAIL(HttpStatus.UNAUTHORIZED, "AUTH_013", "유저 인증에 실패했습니다."),
+    USER_INSUFFICIENT_PERMISSION(HttpStatus.FORBIDDEN, "AUTH_014", "권한이 부족한 사용자 입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/dev/kioki/global/security/config/SecurityConfig.java
+++ b/src/main/java/com/dev/kioki/global/security/config/SecurityConfig.java
@@ -4,6 +4,8 @@ import com.dev.kioki.domain.user.repository.UserRepository;
 import com.dev.kioki.global.common.code.status.SuccessStatus;
 import com.dev.kioki.global.config.WebConfig;
 import com.dev.kioki.global.redis.RedisUtil;
+import com.dev.kioki.global.security.exception.JwtAccessDeniedHandler;
+import com.dev.kioki.global.security.exception.JwtAuthenticationEntryPoint;
 import com.dev.kioki.global.security.filter.CustomLoginFilter;
 import com.dev.kioki.global.security.filter.CustomLogoutHandler;
 import com.dev.kioki.global.security.filter.JwtExceptionFilter;
@@ -36,6 +38,8 @@ public class SecurityConfig {
     private final AuthenticationConfiguration authenticationConfiguration;
     private final RedisUtil redisUtil;
     private final UserRepository userRepository;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Bean
     public AuthenticationManager authenticationManager() throws Exception {
@@ -79,6 +83,10 @@ public class SecurityConfig {
 
         http.sessionManagement(sessionManagement -> sessionManagement
                 .sessionCreationPolicy((SessionCreationPolicy.STATELESS)));
+
+        http.exceptionHandling(configurer -> configurer
+                .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                .accessDeniedHandler(jwtAccessDeniedHandler));
 
         http.authorizeHttpRequests(requests -> requests
                 .requestMatchers(allowUrls).permitAll()

--- a/src/main/java/com/dev/kioki/global/security/exception/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/dev/kioki/global/security/exception/JwtAccessDeniedHandler.java
@@ -1,0 +1,35 @@
+package com.dev.kioki.global.security.exception;
+
+import com.dev.kioki.global.common.BaseResponse;
+import com.dev.kioki.global.security.util.HttpResponseUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.dev.kioki.global.common.code.status.ErrorStatus.USER_INSUFFICIENT_PERMISSION;
+
+@Slf4j
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        BaseResponse<Object> errorResponse = BaseResponse.onFailure(
+                USER_INSUFFICIENT_PERMISSION.getCode(),
+                USER_INSUFFICIENT_PERMISSION.getMessage(),
+                null);
+
+        HttpResponseUtil.setErrorResponse(response, HttpStatus.FORBIDDEN, errorResponse);
+    }
+}

--- a/src/main/java/com/dev/kioki/global/security/exception/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/dev/kioki/global/security/exception/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package com.dev.kioki.global.security.exception;
+
+import com.dev.kioki.global.common.BaseResponse;
+import com.dev.kioki.global.security.util.HttpResponseUtil;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+import static com.dev.kioki.global.common.code.status.ErrorStatus.USER_AUTHENTICATION_FAIL;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            AuthenticationException authException) throws IOException, ServletException {
+
+        log.error("** JwtAuthenticationEntryPoint **");
+
+        BaseResponse<Object> errorResponse = BaseResponse.onFailure(
+                USER_AUTHENTICATION_FAIL.getCode(),
+                USER_AUTHENTICATION_FAIL.getMessage(),
+                null);
+
+        HttpResponseUtil.setErrorResponse(response, HttpStatus.UNAUTHORIZED, errorResponse);
+    }
+}


### PR DESCRIPTION
## ️ 📌 Issue Number
Close #50

## 🔍 개요
- 인증, 인가 실패 처리 로직 추가

## 🔁 변경 사항
✔️ e0f15dca4dc1823a4ce7afc1d75d58871ca916b9 : 인증 실패 처리
- JwtAuthenticationEntryPoint 구현

✔️ b6e26bd4b953bcb8336563dad9c9cea7d7c939aa : 인가 실패 처리
- JwtAccessDeniedHandler

✔️ 74774573eb11783693e5c55bc5287538fdff90c9 : security config에 인증, 인가 실패 처리 핸들러 등록


## 👀 기타 더 이야기해볼 점

