### PR TITLE
🐛 Fix: 허용 OriginPatterns 추가

### DIFF
--- a/src/main/java/com/dev/kioki/global/config/WebConfig.java
+++ b/src/main/java/com/dev/kioki/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.dev.kioki.global.config;
 
 import com.dev.kioki.global.security.annotation.ExtractTokenArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
@@ -23,9 +24,10 @@ public class WebConfig implements WebMvcConfigurer {
         resolvers.add(extractTokenArgumentResolver);
     }
 
+    @Bean
     public static CorsConfigurationSource apiConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:8080", "http://localhost:3000"));
+        configuration.setAllowedOriginPatterns(Arrays.asList("http://localhost:8080", "http://localhost:3000", "https://dev.kioki.site"));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setAllowCredentials(true);


### PR DESCRIPTION
## ️ 📌 Issue Number
Close #54 


## 🔍 개요
- 배포한 서버 스웨거에서 로그인 테스트 했을 때 Response body가 생성이 안되는 에러가 발생했습니다.


## 🔁 변경 사항
✔️ c695cee0bfd395b2cc3df0d3fac14184f351f629 : 허용 OriginPatterns 추가
배포한 서버를 허용하도록 cors 설정에서 허용 OriginPatterns에 배포 서버를 추가했습니다


## 👀 기타 더 이야기해볼 점

